### PR TITLE
feat: multi-arch Docker support (amd64 + arm64)

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,112 @@
+name: Release Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '镜像版本号，例如 v4.2.0'
+        required: true
+        default: 'dev'
+      push:
+        description: '是否推送到 Docker Hub？选 false 则只构建不推送'
+        type: boolean
+        required: false
+        default: false
+      platforms:
+        description: '目标平台（逗号分隔）'
+        required: false
+        default: 'linux/amd64,linux/arm64'
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: app
+            file: docker/Dockerfile.app
+            repo: retainpdf-app
+            build-args: |
+              http_proxy
+              https_proxy
+              HTTP_PROXY
+              HTTPS_PROXY
+              ALL_PROXY
+          - name: web
+            file: docker/Dockerfile.web
+            repo: retainpdf-web
+            build-args: |
+              http_proxy
+              https_proxy
+              HTTP_PROXY
+              HTTPS_PROXY
+              ALL_PROXY
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve Docker Hub namespace
+        id: hub
+        run: |
+          user="${{ secrets.DOCKERHUB_USERNAME }}"
+          if [ -z "$user" ]; then
+            user="${GITHUB_REPOSITORY_OWNER}"
+          fi
+          echo "user=${user}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.hub.outputs.user }}/${{ matrix.target.repo }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Login to Docker Hub
+        if: inputs.push || github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate build args
+        id: build-args
+        run: |
+          args=""
+          for var in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY; do
+            val="$(printenv "$var" || true)"
+            if [ -n "$val" ]; then
+              args="${args} --build-arg ${var}=${val}"
+            fi
+          done
+          # Pass TYPST_VERSION from the Dockerfile default unless overridden
+          if [ -n "${TYPST_VERSION:-}" ]; then
+            args="${args} --build-arg TYPST_VERSION=${TYPST_VERSION}"
+          fi
+          echo "flags=${args}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.target.file }}
+          platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          push: ${{ inputs.push || github.event_name == 'push' }}
+          build-args: ${{ steps.build-args.outputs.flags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM rust:1.81-slim-bookworm AS builder
+FROM rust:1.88-slim-bookworm AS builder
 
 ARG TYPST_VERSION=0.14.2
 ARG CMARKER_VERSION=0.1.8
@@ -34,10 +34,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN mkdir -p /tmp/typst /opt/typst/bin /opt/typst-packages/preview
 
 RUN set -eux; \
-    curl -fsSL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" \
+    ARCH="$(uname -m)"; \
+    case "$ARCH" in \
+      x86_64) TYPST_ARCH="x86_64" ;; \
+      aarch64) TYPST_ARCH="aarch64" ;; \
+      *) echo "Unsupported architecture: $ARCH"; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${TYPST_ARCH}-unknown-linux-musl.tar.xz" \
     -o /tmp/typst/typst.tar.xz \
     && tar -xJf /tmp/typst/typst.tar.xz -C /tmp/typst \
-    && cp /tmp/typst/typst-x86_64-unknown-linux-musl/typst /opt/typst/bin/typst
+    && cp /tmp/typst/typst-${TYPST_ARCH}-unknown-linux-musl/typst /opt/typst/bin/typst
 
 RUN set -eux; \
     for pkg in cmarker:${CMARKER_VERSION} mitex:${MITEX_VERSION}; do \

--- a/docker/build-arm64.sh
+++ b/docker/build-arm64.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TAG="${1:-latest}"
+
+echo "=== Build retainpdf-app (ARM64) ==="
+docker build \
+  -f "${ROOT_DIR}/docker/Dockerfile.app" \
+  -t "retainpdf-app:${TAG}" \
+  "${ROOT_DIR}"
+
+echo "=== Build retainpdf-web (ARM64) ==="
+docker build \
+  -f "${ROOT_DIR}/docker/Dockerfile.web" \
+  -t "retainpdf-web:${TAG}" \
+  "${ROOT_DIR}"
+
+echo ""
+echo "Build done. Start with:"
+echo "  cd ${ROOT_DIR}/docker/delivery"
+echo "  APP_IMAGE=retainpdf-app:${TAG} WEB_IMAGE=retainpdf-web:${TAG} docker compose up -d"


### PR DESCRIPTION
## What

让 Docker 交付支持 `linux/amd64` + `linux/arm64` 双架构，ARM64 服务器（树莓派、Apple Silicon、AWS Graviton 等）可以直接部署。

## Changes

- **`docker/Dockerfile.app`**：typst 下载根据 `uname -m` 自动选 `x86_64` / `aarch64` 包；Rust 基础镜像 1.81 → 1.88（`time` crate 不再兼容旧 toolchain，x86 也会受影响，是必要的修复）
- **`.github/workflows/release-docker.yml`**：新增 CI workflow，`workflow_dispatch` 手动触发测试 + 打 `v*` tag 自动构建并推送双架构镜像到 Docker Hub
- **`docker/build-arm64.sh`**：本地便捷构建脚本

## Tested

- macOS  ARM64（OrbStack）本地构建 + `docker compose up` 完整启动 (MacBook Air M4)
- arm64 Oracle arm服务器 Docker构建成功
- 前端（`:40001`）、Rust API（`:41000`）健康检查通过
- Web 镜像（nginx + Alpine base）原生多架构无需修改

## Maintainer action required

GitHub Secrets 需要配两个值，否则 CI 无法推送镜像：
目前还没有test过，dockerhub的推送，需要further test
本人CI/CD经验有限，可能需要进一步设计

| Secret | 说明 |
|--------|------|
| `DOCKERHUB_USERNAME` | Docker Hub 用户名 |
| `DOCKERHUB_TOKEN` | Docker Hub Access Token |

CI 只在打 `v*` tag 时才构建推送，不影响日常 PR。