### PR TITLE
fix: 保留前端复合渲染进度文案

### DIFF
--- a/doc/core/contributing/testing.md
+++ b/doc/core/contributing/testing.md
@@ -75,9 +75,12 @@ python3 backend/scripts/devtools/check_pipeline_architecture.py
 前端与桌面端：
 
 ```bash
+npm --prefix frontend test
 npm --prefix frontend run build
 npm --prefix desktop run verify-frontend-sync
 ```
+
+`npm --prefix frontend test` 使用 Node 原生 test runner，优先覆盖任务进度、状态整形等不依赖浏览器和后端服务的纯函数回归。
 
 前端端到端状态 smoke 会真实提交任务，通常需要本地 Rust API、OCR token、模型 key 和样本 PDF；具备这些条件时再跑：
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "prepare:vendor": "node ./scripts/prepare-runtime-deps.mjs",
     "smoke:desktop-first-run": "node ./scripts/desktop-first-run-smoke.mjs",
     "smoke:status": "node ./scripts/frontend-status-smoke.mjs",
+    "test": "node --test tests/job-progress.test.mjs",
     "watch:css": "tailwindcss -c tailwind.config.js -i ./src/input.css -o ./styles.css --watch"
   },
   "devDependencies": {

--- a/frontend/src/js/job-stage-presentation.js
+++ b/frontend/src/js/job-stage-presentation.js
@@ -113,7 +113,8 @@ export function resolveDisplayedStagePresentation(job, eventsPayload) {
         progress_total: latestCurrentProgress.total,
       }
     : null;
-  const currentProgressText = latestProgressPayload ? summarizeStageProgressText(latestProgressPayload) : eventProgressText;
+  const currentProgressText = latestCurrentProgress?.progressText
+    || (latestProgressPayload ? summarizeStageProgressText(latestProgressPayload) : eventProgressText);
   const currentVisualPayload = latestProgressPayload || eventPayload;
   const currentSubstagePayload = latestProgressPayload || eventPayload;
   const currentProgressIndeterminate = latestCurrentProgress

--- a/frontend/tests/job-progress.test.mjs
+++ b/frontend/tests/job-progress.test.mjs
@@ -1,0 +1,189 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeJobPayload } from "../src/js/job-normalize.js";
+import {
+  collectStageProgressByKey,
+  resolveDisplayedStagePresentation,
+} from "../src/js/job-stage-presentation.js";
+import { summarizeStageProgressText } from "../src/js/job-status-summary-progress.js";
+
+test("normalizeJobPayload completes progress for succeeded jobs", () => {
+  const job = normalizeJobPayload({
+    code: 0,
+    data: {
+      job_id: "job-1",
+      status: "succeeded",
+      progress: {
+        current: 2,
+        total: 8,
+        percent: 25,
+      },
+    },
+  });
+
+  assert.equal(job.progress_current, 8);
+  assert.equal(job.progress_total, 8);
+  assert.equal(job.progress_percent, 100);
+});
+
+test("summarizeStageProgressText formats stable user-facing progress copy", () => {
+  assert.equal(
+    summarizeStageProgressText({
+      status: "running",
+      current_stage: "translation_batches",
+      progress_current: 2,
+      progress_total: 5,
+      progress_unit: "batch",
+    }),
+    "第 2/5 批",
+  );
+
+  assert.equal(
+    summarizeStageProgressText({
+      status: "running",
+      current_stage: "compile",
+      substage: "render_compile",
+      progress_current: 1,
+      progress_total: 2,
+      progress_unit: "step",
+    }),
+    "编译 1/2",
+  );
+
+  assert.equal(
+    summarizeStageProgressText({
+      status: "running",
+      current_stage: "rendering",
+      substage: "render_prewarm",
+      progress_current: 1,
+      progress_total: 4,
+      progress_unit: "step",
+    }),
+    "预热 1/4",
+  );
+});
+
+test("resolveDisplayedStagePresentation exposes composite render compile progress", () => {
+  const job = {
+    job_id: "job-render",
+    workflow: "book",
+    status: "running",
+    current_stage: "rendering",
+    progress_current: 0,
+    progress_total: 100,
+  };
+  const eventsPayload = {
+    items: [
+      {
+        seq: 1,
+        event_type: "stage_progress",
+        stage: "render_prepare",
+        substage: "render_prepare",
+        progress_current: 1,
+        progress_total: 2,
+        progress_unit: "step",
+      },
+      {
+        seq: 2,
+        event_type: "stage_progress",
+        stage: "rendering",
+        substage: "render_pages",
+        progress_current: 5,
+        progress_total: 10,
+        progress_unit: "page",
+      },
+      {
+        seq: 3,
+        event_type: "stage_progress",
+        stage: "compile",
+        substage: "render_compile",
+        progress_current: 1,
+        progress_total: 2,
+        progress_unit: "step",
+      },
+    ],
+  };
+
+  const presentation = resolveDisplayedStagePresentation(job, eventsPayload);
+
+  assert.equal(presentation.stageKey, "render");
+  assert.equal(presentation.progressCurrent, 90);
+  assert.equal(presentation.progressTotal, 100);
+  assert.equal(presentation.progressUnit, "percent");
+  assert.equal(presentation.progressText, "编译 1/2");
+});
+
+test("resolveDisplayedStagePresentation preserves composite render prewarm progress text", () => {
+  const presentation = resolveDisplayedStagePresentation(
+    {
+      job_id: "job-prewarm",
+      workflow: "book",
+      status: "running",
+      current_stage: "rendering",
+    },
+    {
+      items: [
+        {
+          seq: 1,
+          event_type: "stage_progress",
+          stage: "rendering",
+          substage: "render_prewarm",
+          progress_current: 2,
+          progress_total: 4,
+          progress_unit: "step",
+        },
+      ],
+    },
+  );
+
+  assert.equal(presentation.progressCurrent, 5);
+  assert.equal(presentation.progressTotal, 100);
+  assert.equal(presentation.progressUnit, "percent");
+  assert.equal(presentation.progressText, "预热 2/4");
+});
+
+test("collectStageProgressByKey keeps translation substage progress", () => {
+  const progressByKey = collectStageProgressByKey(
+    {
+      job_id: "job-translate",
+      workflow: "book",
+      status: "running",
+      current_stage: "translation_batches",
+    },
+    {
+      items: [
+        {
+          seq: 1,
+          stage: "continuation_review",
+          substage: "continuation_review",
+          progress_current: 2,
+          progress_total: 10,
+          progress_unit: "page",
+        },
+        {
+          seq: 2,
+          stage: "page_policies",
+          substage: "page_policies",
+          progress_current: 3,
+          progress_total: 10,
+          progress_unit: "page",
+        },
+        {
+          seq: 3,
+          stage: "translation_batches",
+          substage: "translation_batches",
+          progress_current: 4,
+          progress_total: 8,
+          progress_unit: "batch",
+        },
+      ],
+    },
+  );
+
+  assert.equal(progressByKey.translate.current, 4);
+  assert.equal(progressByKey.translate.total, 8);
+  assert.equal(progressByKey.translate.progressText, "第 4/8 批");
+  assert.equal(progressByKey.translate.bySubstage.continuation_review.current, 2);
+  assert.equal(progressByKey.translate.bySubstage.page_policies.current, 3);
+});


### PR DESCRIPTION
## 概要

修复前端任务状态卡在复合渲染进度下的文案回退问题，并补齐不依赖浏览器和后端服务的前端纯函数回归测试入口。

## 修改内容

- 在 `resolveDisplayedStagePresentation` 中优先保留进度记录已经计算好的 `progressText`，避免 `render_compile` / `render_prewarm` 等复合进度被折算百分比后重新显示成 `编译 90/100`、`预热 5/100` 这类内部进度。
- 新增 `npm --prefix frontend test`，使用 Node 原生 test runner 覆盖任务进度归一化、用户可见进度文案、复合渲染进度和翻译子阶段进度。
- 同步测试贡献文档，说明轻量前端测试入口的用途。

## 原因

渲染阶段会把预热、逐页渲染、编译等子进度组合成百分制进度用于进度条展示，但用户可见文案仍应保留原始子阶段语义。此前展示层会基于折算后的 current / total 重新生成文案，导致编译或预热阶段文案不够准确。

## 测试

- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `npm --prefix desktop run verify-frontend-sync`

## AI 辅助说明

本 PR 使用 Codex 辅助阅读贡献文档、定位前端进度展示逻辑、生成回归测试并运行本地检查；最终改动范围和测试结果已人工核对。