### PR TITLE
fix: 修复文件保存无法正确指定保存类型的问题，包块markdown zip下载和已翻译pdf文件下载问题

### DIFF
--- a/backend/rust_api/src/services/jobs/downloads.rs
+++ b/backend/rust_api/src/services/jobs/downloads.rs
@@ -77,7 +77,11 @@ pub fn document_download(
     } else {
         path
     };
-    Ok(FileDownload::new(path, content_type, None))
+    let download_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|s| s.to_string());
+    Ok(FileDownload::new(path, content_type, download_name))
 }
 
 pub fn page_preview_download(

--- a/frontend/src/js/downloads.js
+++ b/frontend/src/js/downloads.js
@@ -13,6 +13,28 @@ function sanitizeSuggestedName(filename) {
   return normalized.replace(/[\\/:*?"<>|]+/g, "_");
 }
 
+function acceptTypesForName(filename) {
+  const sanitized = sanitizeSuggestedName(filename);
+  const dot = sanitized.lastIndexOf(".");
+  if (dot <= 0 || dot === sanitized.length - 1) {
+    return null;
+  }
+  const ext = sanitized.slice(dot).toLowerCase();
+  if (ext === ".pdf") {
+    return [{ description: "PDF 文件", accept: { "application/pdf": [".pdf"] } }];
+  }
+  if (ext === ".zip") {
+    return [{ description: "ZIP 压缩包", accept: { "application/zip": [".zip"] } }];
+  }
+  if (ext === ".md") {
+    return [{ description: "Markdown 文件", accept: { "text/markdown": [".md"] } }];
+  }
+  if (ext === ".json") {
+    return [{ description: "JSON 文件", accept: { "application/json": [".json"] } }];
+  }
+  return null;
+}
+
 function normalizeTotalBytes(response) {
   const headerValue = response?.headers?.get?.("content-length") || "";
   const totalBytes = Number(headerValue);
@@ -158,9 +180,14 @@ export async function prepareDownloadTarget(suggestedName) {
     return { kind: "blob" };
   }
   try {
-    const handle = await window.showSaveFilePicker({
+    const pickerOpts = {
       suggestedName: sanitizeSuggestedName(suggestedName),
-    });
+    };
+    const types = acceptTypesForName(suggestedName);
+    if (types) {
+      pickerOpts.types = types;
+    }
+    const handle = await window.showSaveFilePicker(pickerOpts);
     return { kind: "file-system", handle };
   } catch (error) {
     if (isAbortError(error)) {


### PR DESCRIPTION
 - 修改 `prepareDownloadTarget`：将 `types` 传入 `showSaveFilePicker` 的 `pickerOpts`

    ### 后端 — `backend/rust_api/src/services/jobs/downloads.rs`

    - 修改 `document_download`：从文件路径提取文件名，作为 `download_name` 传入 `FileDownload`，使响应包含
    `Content-Disposition` 头

    ## 测试

    - [x] `cargo build` 编译通过
    - [x] `cargo test --lib routes::job_helpers::tests` 3/3 通过
    - [x] 前端 `npm run build` 构建通过
    - [x] 桌面端实测：保存对话框文件类型过滤器正确显示"PDF 文件(\*.pdf)"