### PR TITLE
同步前端发布版本生成来源

### DIFF
--- a/frontend/scripts/generate-app-version.mjs
+++ b/frontend/scripts/generate-app-version.mjs
@@ -8,6 +8,7 @@ const __dirname = path.dirname(__filename);
 const frontendRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(frontendRoot, "..");
 const desktopPackagePath = path.resolve(frontendRoot, "../desktop/package.json");
+const versionFilePath = path.resolve(repoRoot, "VERSION");
 const outputPath = path.join(frontendRoot, "src/js/generated/app-version.js");
 
 function repoFromHomepage(homepage = "") {
@@ -38,8 +39,21 @@ function readGitVersion() {
   }
 }
 
+function readVersionFile() {
+  try {
+    return fs.readFileSync(versionFilePath, "utf8").trim();
+  } catch (_err) {
+    return "";
+  }
+}
+
 const desktopPackage = JSON.parse(fs.readFileSync(desktopPackagePath, "utf8"));
-const appVersion = desktopPackage.version || readGitVersion() || "0.0.0";
+const packageVersion = `${desktopPackage.version || ""}`.trim();
+const appVersion = (process.env.RETAIN_PDF_VERSION || "").trim()
+  || packageVersion
+  || readGitVersion()
+  || readVersionFile()
+  || "0.0.0";
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(
   outputPath,

--- a/frontend/tests/app-update.test.mjs
+++ b/frontend/tests/app-update.test.mjs
@@ -1,11 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { isNewerVersion } from "../src/js/features/app-update/github-release.js";
 import {
   readUpdateCache,
   writeUpdateCache,
 } from "../src/js/features/app-update/state.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const frontendRoot = path.resolve(__dirname, "..");
+const generatedVersionPath = path.join(frontendRoot, "src/js/generated/app-version.js");
 
 function withLocalStorage(fn) {
   const store = new Map();
@@ -26,6 +35,8 @@ function withLocalStorage(fn) {
 test("isNewerVersion compares beta suffix numbers instead of only major version", () => {
   assert.equal(isNewerVersion("v4.1.6-beta2", "4.1.6-beta1"), true);
   assert.equal(isNewerVersion("v4.1.6-beta1", "4.1.6-beta2"), false);
+  assert.equal(isNewerVersion("v4.1.6-beta10", "4.1.6-beta1"), true);
+  assert.equal(isNewerVersion("v4.1.6-beta1", "4.1.6-beta10"), false);
   assert.equal(isNewerVersion("v4.1.7", "4.1.6-beta9"), true);
 });
 
@@ -46,4 +57,24 @@ test("update cache reports freshness using 24 hour ttl", () => {
     assert.equal(stale.fresh, false);
     assert.equal(stale.info.latestVersion, "4.1.6-beta2");
   });
+});
+
+test("generate-app-version uses release version override", () => {
+  const before = fs.readFileSync(generatedVersionPath, "utf8");
+  try {
+    execFileSync("node", ["./scripts/generate-app-version.mjs"], {
+      cwd: frontendRoot,
+      env: {
+        ...process.env,
+        RETAIN_PDF_VERSION: "9.8.7-beta10",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const generated = fs.readFileSync(generatedVersionPath, "utf8");
+
+    assert.match(generated, /export const APP_VERSION = "9\.8\.7-beta10";/);
+  } finally {
+    fs.writeFileSync(generatedVersionPath, before, "utf8");
+  }
 });


### PR DESCRIPTION
## 背景

桌面打包可以通过 `RETAIN_PDF_VERSION` 覆盖发布版本，但前端 `APP_VERSION` 生成脚本此前只读取 `desktop/package.json`，在发布覆盖版本时可能导致安装包版本与前端“当前版本”显示不一致。

同时补充 `v4.1.6-beta10` 与 `v4.1.6-beta1` 的比较用例，确认 beta10 大于 beta1。

## 改动

- 让 `frontend/scripts/generate-app-version.mjs` 的版本来源顺序与桌面打包保持一致：`RETAIN_PDF_VERSION`、`desktop/package.json`、`git describe`、`VERSION`、`0.0.0`。
- 补充前端单元测试，覆盖 `RETAIN_PDF_VERSION` 生成覆盖和 `beta10 > beta1`。

## 验证

- `npm --prefix frontend test`