### PR TITLE
修复前端更新比较与缓存边界

### DIFF
--- a/frontend/src/js/features/app-update/github-release.js
+++ b/frontend/src/js/features/app-update/github-release.js
@@ -6,29 +6,74 @@ function normalizeVersion(value = "") {
   return `${value || ""}`.trim().replace(/^v/i, "");
 }
 
-function versionParts(value = "") {
-  return normalizeVersion(value).split(/[.+-]/).map((part) => {
-    const match = `${part || ""}`.match(/\d+/);
-    const num = Number.parseInt(match?.[0] || "0", 10);
-    return Number.isFinite(num) ? num : 0;
-  });
+function numericPart(value = "") {
+  const match = `${value || ""}`.match(/\d+/);
+  const num = Number.parseInt(match?.[0] || "0", 10);
+  return Number.isFinite(num) ? num : 0;
 }
 
-export function isNewerVersion(latest = "", current = APP_VERSION) {
-  const latestParts = versionParts(latest);
-  const currentParts = versionParts(current);
+function betaNumber(value = "") {
+  const match = `${value || ""}`.trim().match(/^beta(?:[.+-]?(\d+))?$/i);
+  if (!match) {
+    return null;
+  }
+  return numericPart(match[1] || "0");
+}
+
+function versionParts(value = "") {
+  const [withoutBuild = ""] = normalizeVersion(value).split("+");
+  const prereleaseIndex = withoutBuild.indexOf("-");
+  const core = prereleaseIndex >= 0 ? withoutBuild.slice(0, prereleaseIndex) : withoutBuild;
+  const prerelease = prereleaseIndex >= 0 ? withoutBuild.slice(prereleaseIndex + 1) : "";
+  return {
+    core: core.split(".").map(numericPart),
+    beta: betaNumber(prerelease),
+    stable: !prerelease,
+  };
+}
+
+function compareCoreVersion(latestParts, currentParts) {
   const length = Math.max(latestParts.length, currentParts.length);
   for (let index = 0; index < length; index += 1) {
     const latestPart = latestParts[index] || 0;
     const currentPart = currentParts[index] || 0;
     if (latestPart > currentPart) {
-      return true;
+      return 1;
     }
     if (latestPart < currentPart) {
-      return false;
+      return -1;
     }
   }
-  return false;
+  return 0;
+}
+
+function compareBetaVersion(latestParts, currentParts) {
+  const latestIsBeta = latestParts.beta !== null;
+  const currentIsBeta = currentParts.beta !== null;
+  if (latestParts.stable && currentIsBeta) {
+    return 1;
+  }
+  if (latestIsBeta && currentParts.stable) {
+    return -1;
+  }
+  if (!latestIsBeta || !currentIsBeta) {
+    return 0;
+  }
+  return latestParts.beta - currentParts.beta;
+}
+
+function compareVersions(latest, current) {
+  const latestParts = versionParts(latest);
+  const currentParts = versionParts(current);
+  const coreResult = compareCoreVersion(latestParts.core, currentParts.core);
+  if (coreResult !== 0) {
+    return coreResult;
+  }
+  return compareBetaVersion(latestParts, currentParts);
+}
+
+export function isNewerVersion(latest = "", current = APP_VERSION) {
+  return compareVersions(latest, current) > 0;
 }
 
 export async function fetchLatestGithubRelease() {

--- a/frontend/src/js/features/app-update/state.js
+++ b/frontend/src/js/features/app-update/state.js
@@ -34,9 +34,10 @@ export function readUpdateCache(now = Date.now()) {
     if (!cached) {
       return { info: null, fresh: false };
     }
+    const ageMs = now - cached.checkedAt;
     return {
       info: cached,
-      fresh: now - cached.checkedAt < CACHE_TTL_MS,
+      fresh: ageMs >= 0 && ageMs < CACHE_TTL_MS,
     };
   } catch {
     return { info: null, fresh: false };

--- a/frontend/tests/app-update.test.mjs
+++ b/frontend/tests/app-update.test.mjs
@@ -26,7 +26,19 @@ function withLocalStorage(fn) {
 test("isNewerVersion compares beta suffix numbers instead of only major version", () => {
   assert.equal(isNewerVersion("v4.1.6-beta2", "4.1.6-beta1"), true);
   assert.equal(isNewerVersion("v4.1.6-beta1", "4.1.6-beta2"), false);
+  assert.equal(isNewerVersion("v4.1.6-beta10", "4.1.6-beta1"), true);
+  assert.equal(isNewerVersion("v4.1.6-beta1", "4.1.6-beta10"), false);
   assert.equal(isNewerVersion("v4.1.7", "4.1.6-beta9"), true);
+});
+
+test("isNewerVersion treats stable releases as newer than prereleases", () => {
+  assert.equal(isNewerVersion("v4.1.6", "4.1.6-beta10"), true);
+  assert.equal(isNewerVersion("v4.1.6-beta10", "4.1.6"), false);
+});
+
+test("isNewerVersion ignores unsupported prerelease labels", () => {
+  assert.equal(isNewerVersion("v4.1.6-preview1", "4.1.6-beta10"), false);
+  assert.equal(isNewerVersion("v4.1.6-beta10", "4.1.6-preview1"), false);
 });
 
 test("update cache reports freshness using 24 hour ttl", () => {
@@ -45,5 +57,20 @@ test("update cache reports freshness using 24 hour ttl", () => {
     const stale = readUpdateCache(1000 + 25 * 60 * 60 * 1000);
     assert.equal(stale.fresh, false);
     assert.equal(stale.info.latestVersion, "4.1.6-beta2");
+  });
+});
+
+test("update cache treats future timestamps as stale", () => {
+  withLocalStorage(() => {
+    writeUpdateCache({
+      currentVersion: "4.1.6-beta1",
+      latestVersion: "4.1.6-beta2",
+      hasUpdate: true,
+    }, 2000);
+
+    const cached = readUpdateCache(1000);
+
+    assert.equal(cached.fresh, false);
+    assert.equal(cached.info.latestVersion, "4.1.6-beta2");
   });
 });


### PR DESCRIPTION
## 背景

前端更新检测需要更准确地处理当前项目使用的 stable / beta 版本形态，并避免异常缓存时间戳影响真实更新检查。

## 改动

- 收窄版本比较逻辑，只处理 stable 与 beta：同号 stable 高于 beta，beta 后缀按数字比较。
- 未支持的预发布标签不参与排序，避免引入额外版本语义。
- 缓存时间戳来自未来时不再视为 fresh，避免跳过真实检查。
- 补充对应前端单元测试。

## 验证

- `npm --prefix frontend test`