### PR TITLE
修复长文件名导致的 PDF 渲染失败

### DIFF
--- a/backend/python-tests/rendering/test_render_source_paths.py
+++ b/backend/python-tests/rendering/test_render_source_paths.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pikepdf
+
+from services.rendering.source.render_source import build_render_source_pdf
+
+
+def test_render_source_accepts_output_name_near_filesystem_limit(tmp_path: Path) -> None:
+    source_pdf = tmp_path / "source.pdf"
+    with pikepdf.Pdf.new() as pdf:
+        pdf.add_blank_page(page_size=(100, 100))
+        pdf.save(source_pdf)
+
+    pathconf = getattr(os, "pathconf", None)
+    name_max = int(pathconf(tmp_path, "PC_NAME_MAX")) if pathconf is not None else 255
+    output_stem = "a" * (name_max - len(".pdf"))
+    output_pdf = tmp_path / f"{output_stem}.pdf"
+    derived_name = f"{output_pdf.stem}.source-xobject-sanitized.pdf"
+    assert len(os.fsencode(derived_name)) > name_max
+
+    result = build_render_source_pdf(
+        source_pdf_path=source_pdf,
+        output_pdf_path=output_pdf,
+        pdf_compress_dpi=0,
+        strip_hidden_text=False,
+        artifact_mode=True,
+    )
+
+    assert result.path == source_pdf

--- a/backend/scripts/services/rendering/source/intermediate_paths.py
+++ b/backend/scripts/services/rendering/source/intermediate_paths.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+
+# Stay below common 255-byte component limits and leave room for filesystem
+# encoding or normalization differences.
+_SAFE_FILENAME_BYTES = 240
+
+
+def intermediate_pdf_path(
+    *,
+    work_root: Path,
+    output_pdf_path: Path,
+    suffix: str,
+) -> Path:
+    filename = f"{output_pdf_path.stem}{suffix}"
+    if len(os.fsencode(filename)) <= _filename_byte_limit(work_root):
+        return work_root / filename
+
+    digest = hashlib.sha256(os.fsencode(output_pdf_path.name)).hexdigest()[:16]
+    return work_root / f"{digest}{suffix}"
+
+
+def _filename_byte_limit(work_root: Path) -> int:
+    pathconf = getattr(os, "pathconf", None)
+    if pathconf is None:
+        return _SAFE_FILENAME_BYTES
+    try:
+        name_max = int(pathconf(work_root, "PC_NAME_MAX"))
+    except (OSError, TypeError, ValueError):
+        return _SAFE_FILENAME_BYTES
+    if name_max <= 0:
+        return _SAFE_FILENAME_BYTES
+    return min(name_max, _SAFE_FILENAME_BYTES)
+
+
+__all__ = ["intermediate_pdf_path"]

--- a/backend/scripts/services/rendering/source/render_source.py
+++ b/backend/scripts/services/rendering/source/render_source.py
@@ -6,6 +6,7 @@ import time
 
 from services.rendering.source.compression.pdf_copy import build_image_compressed_pdf_copy
 from services.rendering.contracts import RenderDocumentAnalysis
+from services.rendering.source.intermediate_paths import intermediate_pdf_path
 from services.rendering.source_cleanup.types import BBoxTextStripCandidates
 from services.rendering.source.preparation.hidden_text_strip import build_hidden_text_stripped_pdf_copy
 from services.rendering.source.preparation.xobject_sanitize import build_invalid_xobject_sanitized_pdf_copy
@@ -55,7 +56,11 @@ def build_render_source_pdf(
     source_text_precleaned_page_indices: frozenset[int] = frozenset()
     source_cleanup_cover_fallback_page_indices: frozenset[int] = frozenset()
     sanitize_started = time.perf_counter()
-    sanitized_source_path = work_root / f"{output_pdf_path.stem}.source-xobject-sanitized.pdf"
+    sanitized_source_path = intermediate_pdf_path(
+        work_root=work_root,
+        output_pdf_path=output_pdf_path,
+        suffix=".source-xobject-sanitized.pdf",
+    )
     sanitize_result = build_invalid_xobject_sanitized_pdf_copy(
         source_pdf_path=render_source_path,
         output_pdf_path=sanitized_source_path,
@@ -75,7 +80,11 @@ def build_render_source_pdf(
     hidden_text_page_indices = document_analysis.hidden_text_strip_page_indices if document_analysis is not None else frozenset()
     if strip_hidden_text and hidden_text_page_indices:
         hidden_started = time.perf_counter()
-        hidden_text_stripped_path = work_root / f"{output_pdf_path.stem}.source-hidden-text-stripped.pdf"
+        hidden_text_stripped_path = intermediate_pdf_path(
+            work_root=work_root,
+            output_pdf_path=output_pdf_path,
+            suffix=".source-hidden-text-stripped.pdf",
+        )
         hidden_text_result = build_hidden_text_stripped_pdf_copy(
             render_source_path,
             hidden_text_stripped_path,
@@ -110,7 +119,11 @@ def build_render_source_pdf(
             )
         else:
             bbox_started = time.perf_counter()
-            bbox_text_stripped_path = work_root / f"{output_pdf_path.stem}.source-bbox-text-stripped.pdf"
+            bbox_text_stripped_path = intermediate_pdf_path(
+                work_root=work_root,
+                output_pdf_path=output_pdf_path,
+                suffix=".source-bbox-text-stripped.pdf",
+            )
             source_cleanup_result = execute_source_cleanup(
                 SourceCleanupRequest(
                     source_pdf_path=render_source_path,
@@ -167,8 +180,10 @@ def build_render_source_pdf(
             document_analysis=document_analysis,
         )
     compress_started = time.perf_counter()
-    compressed_source_path = (
-        work_root / f"{output_pdf_path.stem}.source-compressed.pdf"
+    compressed_source_path = intermediate_pdf_path(
+        work_root=work_root,
+        output_pdf_path=output_pdf_path,
+        suffix=".source-compressed.pdf",
     )
     if build_image_compressed_pdf_copy(render_source_path, compressed_source_path, dpi=pdf_compress_dpi):
         print(f"render source pdf: image compression elapsed={time.perf_counter() - compress_started:.2f}s", flush=True)

--- a/backend/scripts/services/rendering/workflow/modes.py
+++ b/backend/scripts/services/rendering/workflow/modes.py
@@ -13,6 +13,7 @@ from services.rendering.output.typst.book_renderer import build_book_typst_pdf
 from services.rendering.output.typst.book_renderer import build_dual_book_pdf
 from services.rendering.workflow.context import RenderExecutionContext
 from services.rendering.output.typst.shared import default_typst_temp_root
+from services.rendering.source.intermediate_paths import intermediate_pdf_path
 
 
 def _compress_final_pdf_if_needed(context: RenderExecutionContext, *, mode: str) -> bool:
@@ -67,7 +68,11 @@ def run_selected_pages_overlay_render(
     translated_pages: dict[int, list[dict]],
     context: RenderExecutionContext,
 ) -> tuple[int, dict[str, object]]:
-    selected_source_path = default_typst_temp_root(context.output_pdf_path) / f"{context.output_pdf_path.stem}.selected-source.pdf"
+    selected_source_path = intermediate_pdf_path(
+        work_root=default_typst_temp_root(context.output_pdf_path),
+        output_pdf_path=context.output_pdf_path,
+        suffix=".selected-source.pdf",
+    )
     extract_pages_with_pikepdf(
         source_pdf_path=source_pdf_path,
         output_pdf_path=selected_source_path,


### PR DESCRIPTION
## 问题

当最终输出 PDF 的文件名接近文件系统单个路径组件上限时，`render_source.py` 会继续在完整的 `output_pdf_path.stem` 后拼接 `.source-xobject-sanitized.pdf` 等后缀。最终输出名本身仍然合法，但派生的中间文件名可能超过 macOS/Linux 常见的 255 字节限制，导致渲染阶段抛出 `OSError: [Errno 63] File name too long`。

这个问题发生在翻译完成后的渲染预处理阶段：翻译结果已经生成，但任务最终仍会被标记为失败。隐藏文本清理、bbox 文本清理、源 PDF 压缩和选页渲染的中间路径也存在相同风险。

## 变更

- 新增统一的 `intermediate_pdf_path`：
  - 短名称继续沿用现有命名，不改变常规任务的中间产物；
  - 超过安全字节阈值时，使用最终输出名的 SHA-256 短摘要并保留用途后缀；
  - 读取 `PC_NAME_MAX`，不可用时采用保守的 240 字节上限；
  - 摘要命名保持确定性，避免恢复或重跑时路径漂移。
- 将 `render_source.py` 中的 xobject sanitize、hidden text strip、bbox text strip、compression，以及 `workflow/modes.py` 中的 selected-source 路径统一切换到该 helper。
- 新增回归测试，构造合法但接近文件系统名称上限的输出名；旧实现可稳定复现 `Errno 63`，修复后通过。

## 验证

- 相关渲染回归测试：`34 passed`
- Pipeline architecture check：通过
- `compileall`：通过
- 使用实际触发样本重放渲染源预处理：通过（最终输出名 237 字节，旧派生中间名 262 字节）
- 全量渲染测试：`302 passed, 1 skipped, 5 failed`
  - 5 个失败来自本机已有的 macOS 环境差异：3 个 `/var` 与 `/private/var` 路径解析断言、2 个测试硬编码 Linux 字体路径；与本次改动无关。

## 风险与兼容性

- 仅改变超长内部中间 PDF 的文件名，不改变最终 PDF 文件名或 PDF 内容。
- 不改变 `document.v1`、translation manifest、render payload 或阶段事件。
- 旧 job 的重新渲染和断点恢复仍使用确定性的中间路径。