### PR TITLE
修复旋转 PDF 页面在 side-by-side 输出中视觉效果错误

### DIFF
--- a/backend/scripts/devtools/tests/rendering/test_side_by_side_pdf.py
+++ b/backend/scripts/devtools/tests/rendering/test_side_by_side_pdf.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 
 import fitz
+from PIL import Image
+from PIL import ImageChops
 
 
 REPO_SCRIPTS_ROOT = Path(__file__).resolve().parents[3]
@@ -17,6 +19,32 @@ def _write_pdf(path: Path, page_sizes: list[tuple[int, int]], label: str) -> Non
         page.insert_text((24, 36), f"{label} {index + 1}")
     doc.save(path)
     doc.close()
+
+
+def _write_marker_pdf(
+    path: Path,
+    *,
+    width: int,
+    height: int,
+    rotation: int,
+    colors: list[tuple[float, float, float]],
+) -> None:
+    doc = fitz.open()
+    page = doc.new_page(width=width, height=height)
+    page.draw_rect(fitz.Rect(20, 20, 60, 60), color=colors[0], fill=colors[0])
+    page.draw_rect(fitz.Rect(140, 20, 180, 60), color=colors[1], fill=colors[1])
+    page.draw_rect(fitz.Rect(20, 240, 60, 280), color=colors[2], fill=colors[2])
+    page.draw_rect(fitz.Rect(140, 240, 180, 280), color=colors[3], fill=colors[3])
+    page.draw_rect(fitz.Rect(80, 120, 120, 160), color=(0, 0, 0), fill=(0, 0, 0))
+    page.set_rotation(rotation)
+    doc.save(path)
+    doc.close()
+
+
+def _render_page_image(path: Path, *, page_index: int = 0) -> Image.Image:
+    with fitz.open(path) as doc:
+        pix = doc[page_index].get_pixmap(alpha=False)
+    return Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
 
 
 def test_build_side_by_side_pdf_places_source_and_translation_pages(tmp_path: Path) -> None:
@@ -37,3 +65,44 @@ def test_build_side_by_side_pdf_places_source_and_translation_pages(tmp_path: Pa
         assert "source 1" in doc[0].get_text()
         assert "translated 1" in doc[0].get_text()
         assert "source 2" in doc[1].get_text()
+
+
+def test_build_side_by_side_pdf_preserves_rotated_page_appearance(tmp_path: Path) -> None:
+    source_pdf = tmp_path / "source-rotated.pdf"
+    translated_pdf = tmp_path / "translated-rotated.pdf"
+    output_pdf = tmp_path / "side-by-side-rotated.pdf"
+    _write_marker_pdf(
+        source_pdf,
+        width=200,
+        height=300,
+        rotation=90,
+        colors=[(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 0)],
+    )
+    _write_marker_pdf(
+        translated_pdf,
+        width=200,
+        height=300,
+        rotation=270,
+        colors=[(1, 0, 1), (0, 1, 1), (0.5, 0.2, 0), (0, 0, 0.5)],
+    )
+
+    build_side_by_side_pdf(source_pdf, translated_pdf, output_pdf)
+
+    source_image = _render_page_image(source_pdf)
+    translated_image = _render_page_image(translated_pdf)
+    output_image = _render_page_image(output_pdf)
+
+    expected_height = max(source_image.height, translated_image.height)
+    assert output_image.size == (source_image.width + translated_image.width, expected_height)
+    left_half = output_image.crop((0, 0, source_image.width, source_image.height))
+    right_half = output_image.crop(
+        (
+            source_image.width,
+            0,
+            source_image.width + translated_image.width,
+            expected_height,
+        )
+    )
+
+    assert ImageChops.difference(source_image, left_half).getbbox() is None
+    assert ImageChops.difference(translated_image, right_half).getbbox() is None

--- a/backend/scripts/services/rendering/tools/side_by_side_pdf.py
+++ b/backend/scripts/services/rendering/tools/side_by_side_pdf.py
@@ -12,6 +12,8 @@ def build_side_by_side_pdf(source_pdf: Path, translated_pdf: Path, output_pdf: P
             raise RuntimeError(f"source pdf has no pages: {source_pdf}")
         if translated_doc.page_count < 1:
             raise RuntimeError(f"translated pdf has no pages: {translated_pdf}")
+        _normalize_page_rotations(source_doc)
+        _normalize_page_rotations(translated_doc)
         page_count = max(source_doc.page_count, translated_doc.page_count)
         output_pdf.parent.mkdir(parents=True, exist_ok=True)
         with fitz.open() as out_doc:
@@ -46,6 +48,12 @@ def _page_rect(doc: fitz.Document, page_index: int) -> fitz.Rect | None:
     if page_index >= doc.page_count:
         return None
     return doc[page_index].rect
+
+
+def _normalize_page_rotations(doc: fitz.Document) -> None:
+    for page in doc:
+        if page.rotation:
+            page.remove_rotation()
 
 
 def main() -> None:


### PR DESCRIPTION
在构建输出前调用 remove_rotation() 将页面旋转烘焙到内容中，确保
show_pdf_page 正确放置页面。添加对应的像素级对比测试。