### PR TITLE
feat(ai): add Atlas Cloud environment fallback

### DIFF
--- a/backend/ai_service/retainpdf_ai/config.py
+++ b/backend/ai_service/retainpdf_ai/config.py
@@ -43,15 +43,30 @@ def load_settings() -> Settings:
         if key.strip()
     )
     data_root = os.environ.get("RETAIN_AI_DATA_ROOT", "").strip()
+    atlascloud_api_key = os.environ.get("ATLASCLOUD_API_KEY", "").strip()
+    llm_api_key = os.environ.get("RETAIN_AI_LLM_API_KEY", "").strip()
+    use_atlascloud_defaults = bool(atlascloud_api_key and not llm_api_key)
+    default_llm_base_url = (
+        "https://api.atlascloud.ai/v1"
+        if use_atlascloud_defaults
+        else "https://api.deepseek.com/v1"
+    )
+    default_llm_model = (
+        "deepseek-ai/deepseek-v4-pro"
+        if use_atlascloud_defaults
+        else "deepseek-v4-flash"
+    )
     return Settings(
         host=os.environ.get("RETAIN_AI_HOST", "127.0.0.1"),
         port=int(os.environ.get("RETAIN_AI_PORT", "41100")),
         api_keys=api_keys,
         rust_api_base=os.environ.get("RETAIN_AI_RUST_API_BASE", "http://127.0.0.1:41000").rstrip("/"),
         rust_api_key=os.environ.get("RETAIN_AI_RUST_API_KEY", "").strip(),
-        llm_base_url=os.environ.get("RETAIN_AI_LLM_BASE_URL", "https://api.deepseek.com/v1").rstrip("/"),
-        llm_model=os.environ.get("RETAIN_AI_LLM_MODEL", "deepseek-v4-flash"),
-        llm_api_key=os.environ.get("RETAIN_AI_LLM_API_KEY", "").strip(),
+        llm_base_url=os.environ.get(
+            "RETAIN_AI_LLM_BASE_URL", default_llm_base_url
+        ).rstrip("/"),
+        llm_model=os.environ.get("RETAIN_AI_LLM_MODEL", default_llm_model),
+        llm_api_key=llm_api_key or atlascloud_api_key,
         llm_timeout_s=float(os.environ.get("RETAIN_AI_LLM_TIMEOUT_S", "60")),
         max_tool_rounds=int(os.environ.get("RETAIN_AI_MAX_TOOL_ROUNDS", "6")),
         memory_window_turns=int(os.environ.get("RETAIN_AI_MEMORY_WINDOW_TURNS", "6")),

--- a/backend/ai_service/tests/test_config.py
+++ b/backend/ai_service/tests/test_config.py
@@ -1,0 +1,27 @@
+from retainpdf_ai.config import load_settings
+
+
+def test_atlascloud_key_uses_atlascloud_defaults(monkeypatch):
+    monkeypatch.delenv("RETAIN_AI_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("RETAIN_AI_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("RETAIN_AI_LLM_MODEL", raising=False)
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-test-key")
+
+    settings = load_settings()
+
+    assert settings.llm_api_key == "atlas-test-key"
+    assert settings.llm_base_url == "https://api.atlascloud.ai/v1"
+    assert settings.llm_model == "deepseek-ai/deepseek-v4-pro"
+
+
+def test_explicit_llm_settings_take_priority_over_atlascloud(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-test-key")
+    monkeypatch.setenv("RETAIN_AI_LLM_API_KEY", "explicit-key")
+    monkeypatch.setenv("RETAIN_AI_LLM_BASE_URL", "https://llm.example.test/v1/")
+    monkeypatch.setenv("RETAIN_AI_LLM_MODEL", "example-model")
+
+    settings = load_settings()
+
+    assert settings.llm_api_key == "explicit-key"
+    assert settings.llm_base_url == "https://llm.example.test/v1"
+    assert settings.llm_model == "example-model"


### PR DESCRIPTION
## 变更

- 当未配置 `RETAIN_AI_LLM_API_KEY` 时，允许 AI 服务使用 `ATLASCLOUD_API_KEY`
- 在该回退路径中自动选择 Atlas Cloud OpenAI-compatible endpoint 和默认模型
- 保留所有显式 `RETAIN_AI_LLM_*` 配置的现有优先级，并增加配置契约测试

## 验证

- `PYTHONPATH=. /usr/bin/python3 -m pytest tests/test_config.py -q`（2 passed）
- `PYTHONPATH=. /usr/bin/python3 -m pytest tests/ -q`（35 passed）
- `uvx ruff check retainpdf_ai/config.py tests/test_config.py`
- `python3 -m compileall -q retainpdf_ai tests`
- Atlas Cloud 模型目录、默认模型存在性和经 `build_deepseek_chat_fn` 的 live chat 均验证通过

## 风险

- 回退仅在没有显式 LLM API key 时启用；现有显式配置行为不变。