### PR TITLE
fix: 图书馆分页只显示24本 / 合集无法滚动 / 合集加载失败无重试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ data/downloads/
 backend/rust_api/target/
 backend/rust_api/auth.local.json
 backend/scripts/.env/*.env
+secrets/
+docker/delivery/docker-compose.override.yml
+output/mcp-downloads/
 frontend/node_modules/
 frontend/desktop_app/src-tauri/target/
 untitled.txt

--- a/backend/rust_api/src/api_tests/library_data.rs
+++ b/backend/rust_api/src/api_tests/library_data.rs
@@ -72,6 +72,8 @@ async fn documents_list_and_patch_roundtrip() {
     assert_eq!(response.status(), StatusCode::OK);
     let payload = json_response(response).await;
     assert_eq!(payload["data"]["documents"][0]["document_id"], document_id);
+    // total 是跨页总数,前端分页 hasMore 判断依赖它(缺它会退化为只看第一页)
+    assert_eq!(payload["data"]["total"], 1);
     assert_eq!(
         payload["data"]["documents"][0]["source_pdf_url"],
         format!("http://127.0.0.1:41000/api/v1/documents/{document_id}/source.pdf")

--- a/backend/rust_api/src/db/documents.rs
+++ b/backend/rust_api/src/db/documents.rs
@@ -90,36 +90,7 @@ impl Db {
         collection_id: Option<&str>,
     ) -> Result<Vec<DocumentRecord>> {
         let conn = self.connect()?;
-        // 防御性:图书馆列表永不返回无 upload 支撑的孤儿文档(源文件已丢的
-        // 僵尸卡)。"只入库"文档有 upload 只是没 job,不受影响。
-        let mut clauses: Vec<String> = vec![
-            "EXISTS (SELECT 1 FROM uploads u WHERE u.content_hash = d.document_id AND u.content_hash <> '')"
-                .to_string(),
-        ];
-        let mut args: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-        if let Some(status) = reading_status {
-            clauses.push(format!("d.reading_status = ?{}", args.len() + 1));
-            args.push(Box::new(status.to_string()));
-        }
-        if let Some(tag) = tag {
-            clauses.push(format!(
-                "EXISTS (SELECT 1 FROM document_tags t WHERE t.document_id = d.document_id AND t.tag = ?{})",
-                args.len() + 1
-            ));
-            args.push(Box::new(tag.to_string()));
-        }
-        if let Some(collection_id) = collection_id {
-            clauses.push(format!(
-                "EXISTS (SELECT 1 FROM collection_documents c WHERE c.document_id = d.document_id AND c.collection_id = ?{})",
-                args.len() + 1
-            ));
-            args.push(Box::new(collection_id.to_string()));
-        }
-        let where_sql = if clauses.is_empty() {
-            String::new()
-        } else {
-            format!("WHERE {}", clauses.join(" AND "))
-        };
+        let (where_sql, mut args) = build_document_filters(reading_status, tag, collection_id);
         let sql = format!(
             "SELECT {DOCUMENT_COLUMNS} FROM documents d {where_sql} ORDER BY d.added_at DESC LIMIT ?{} OFFSET ?{}",
             args.len() + 1,
@@ -140,6 +111,24 @@ impl Db {
             document.tags = load_document_tags(&conn, &document.document_id)?;
         }
         Ok(documents)
+    }
+
+    /// 与 list_documents 同一套过滤条件的总数,供前端分页的 hasMore 判断。
+    pub fn count_documents(
+        &self,
+        reading_status: Option<&str>,
+        tag: Option<&str>,
+        collection_id: Option<&str>,
+    ) -> Result<i64> {
+        let conn = self.connect()?;
+        let (where_sql, args) = build_document_filters(reading_status, tag, collection_id);
+        let sql = format!("SELECT COUNT(*) FROM documents d {where_sql}");
+        let count = conn.query_row(
+            &sql,
+            rusqlite::params_from_iter(args.iter().map(|value| value.as_ref())),
+            |row| row.get(0),
+        )?;
+        Ok(count)
     }
 
     pub fn update_document_fields(
@@ -749,6 +738,45 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 
 const DOCUMENT_COLUMNS: &str = "d.document_id, d.title, d.authors_json, d.year, d.doi, d.source_filename, d.page_count, d.bytes, d.active_job_id, d.reading_status, d.added_at, d.last_opened_at, d.updated_at";
 
+/// list/count 共用的文档过滤子句(含“必须有 upload 支撑”的防御条件)。
+fn build_document_filters(
+    reading_status: Option<&str>,
+    tag: Option<&str>,
+    collection_id: Option<&str>,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    // 防御性:图书馆列表永不返回无 upload 支撑的孤儿文档(源文件已丢的
+    // 僵尸卡)。"只入库"文档有 upload 只是没 job,不受影响。
+    let mut clauses: Vec<String> = vec![
+        "EXISTS (SELECT 1 FROM uploads u WHERE u.content_hash = d.document_id AND u.content_hash <> '')"
+            .to_string(),
+    ];
+    let mut args: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    if let Some(status) = reading_status {
+        clauses.push(format!("d.reading_status = ?{}", args.len() + 1));
+        args.push(Box::new(status.to_string()));
+    }
+    if let Some(tag) = tag {
+        clauses.push(format!(
+            "EXISTS (SELECT 1 FROM document_tags t WHERE t.document_id = d.document_id AND t.tag = ?{})",
+            args.len() + 1
+        ));
+        args.push(Box::new(tag.to_string()));
+    }
+    if let Some(collection_id) = collection_id {
+        clauses.push(format!(
+            "EXISTS (SELECT 1 FROM collection_documents c WHERE c.document_id = d.document_id AND c.collection_id = ?{})",
+            args.len() + 1
+        ));
+        args.push(Box::new(collection_id.to_string()));
+    }
+    let where_sql = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", clauses.join(" AND "))
+    };
+    (where_sql, args)
+}
+
 fn default_title_from_filename(filename: &str) -> String {
     filename
         .strip_suffix(".pdf")
@@ -1017,8 +1045,8 @@ mod tests {
         let version: i64 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("user_version");
-        // 与迁移数组长度同步:v1 图书馆地基 + v2 资产/会话
-        assert_eq!(version, 2);
+        // 与迁移数组长度同步:v1 图书馆地基 + v2 资产/会话 + v3 消息树分支
+        assert_eq!(version, 3);
     }
 
     #[test]

--- a/backend/rust_api/src/models/library.rs
+++ b/backend/rust_api/src/models/library.rs
@@ -153,6 +153,8 @@ pub struct ListDocumentsQuery {
 #[derive(Debug, Serialize)]
 pub struct DocumentListView {
     pub documents: Vec<DocumentRecord>,
+    /// 满足过滤条件的文档总数(跨全部页);前端分页 hasMore 判断依赖它。
+    pub total: i64,
 }
 
 /// PATCH /api/v1/documents/:id

--- a/backend/rust_api/src/services/library/documents.rs
+++ b/backend/rust_api/src/services/library/documents.rs
@@ -77,13 +77,14 @@ pub fn list_documents(
         .map(str::trim)
         .filter(|id| !id.is_empty())
     {
-        let documents = deps
+        let documents: Vec<_> = deps
             .db
             .get_document_by_job_id(job_id)?
             .into_iter()
             .map(|doc| with_document_media_urls(doc, base_url))
             .collect();
-        return Ok(DocumentListView { documents });
+        let total = documents.len() as i64;
+        return Ok(DocumentListView { documents, total });
     }
     let documents = deps
         .db
@@ -97,7 +98,12 @@ pub fn list_documents(
         .into_iter()
         .map(|doc| with_document_media_urls(doc, base_url))
         .collect();
-    Ok(DocumentListView { documents })
+    let total = deps.db.count_documents(
+        query.reading_status.as_deref(),
+        query.tag.as_deref(),
+        query.collection_id.as_deref(),
+    )?;
+    Ok(DocumentListView { documents, total })
 }
 
 pub fn get_document(

--- a/frontend/src/pages/home/features/library/categories/CategoriesView.tsx
+++ b/frontend/src/pages/home/features/library/categories/CategoriesView.tsx
@@ -6,7 +6,7 @@
 // 数据形状和图书馆首页卡片完全一致,直接复用 BookCard,不用
 // 另外做一套"文件夹详情卡片"渲染,也不会有第二套删除确认气泡状态。
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useHomeServices } from "../../../home-services-context.js";
 import { useStoreSnapshot } from "../../../../../shared/react/use-store.js";
 import { EmptyState } from "../../../../../shared/icons/EmptyState.jsx";
@@ -89,6 +89,12 @@ export function CategoriesView() {
   const [folderLoading, setFolderLoading] = useState(false);
   const [folderError, setFolderError] = useState("");
 
+  // 桌面端启动早期 rust_api 未就绪(日志里见过 90s 端口等待超时)、或后端
+  // 被大任务短暂拖住时,一次失败不该直接把用户拍在错误态——列表与文件夹
+  // 内容各自动重试一次(1.5s),仍失败才亮错误 + 手动重试入口。
+  const listAutoRetriedRef = useRef(false);
+  const reloadRef = useRef(null);
+
   const reload = useCallback((options: { soft?: boolean } = {}) => {
     // soft：version bump / 二次拉取时保留旧列表，不整表切成 loading（分类 tab 闪一下）
     const soft = Boolean(options.soft);
@@ -99,6 +105,7 @@ export function CategoriesView() {
     return controller
       .listCollections()
       .then(({ collections: items = [] } = {}) => {
+        listAutoRetriedRef.current = false;
         setCollections(items);
         // 正在查看的文件夹如果被删了(管理弹窗里点了删除),退回文件夹网格。
         setOpenFolder((current) => {
@@ -108,14 +115,26 @@ export function CategoriesView() {
           const stillExists = items.some((item) => item.collection_id === current.collection_id);
           return stillExists ? items.find((item) => item.collection_id === current.collection_id) : null;
         });
+        if (!soft) {
+          setListLoading(false);
+        }
       })
-      .catch((err) => setListError(err?.message || "读取合集失败，请稍后重试。"))
-      .finally(() => {
+      .catch((err) => {
+        if (!listAutoRetriedRef.current) {
+          // 瞬时故障:静默自动重试一次,保持 loading 不闪错误
+          listAutoRetriedRef.current = true;
+          window.setTimeout(() => {
+            void reloadRef.current?.();
+          }, 1500);
+          return;
+        }
+        setListError(err?.message || "读取合集失败，请稍后重试。");
         if (!soft) {
           setListLoading(false);
         }
       });
   }, [controller]);
+  reloadRef.current = reload;
 
   useEffect(() => {
     // 首屏 hard loading；管理弹窗 bump version 后 soft 刷新
@@ -157,6 +176,9 @@ export function CategoriesView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [controller, collectionIdsKey, version]);
 
+  // 文件夹内容手动重试:folderRetryTick 进 effect 依赖,+1 即重新拉取。
+  const [folderRetryTick, setFolderRetryTick] = useState(0);
+
   const openFolderId = openFolder?.collection_id || "";
   useEffect(() => {
     if (!openFolderId) {
@@ -165,28 +187,37 @@ export function CategoriesView() {
       return undefined;
     }
     let cancelled = false;
+    // 与合集列表同一口径:瞬时失败自动重试一次,仍失败才亮错误。
+    let autoRetried = false;
     setFolderLoading(true);
     setFolderError("");
-    controller
-      .fetchFolderBooks(openFolderId)
-      .then((items) => {
-        if (cancelled) {
-          return;
-        }
-        setFolderItems(items);
-      })
-      .catch((err) => {
-        if (cancelled) {
-          return;
-        }
-        setFolderError(err?.message || "读取合集内容失败，请稍后重试。");
-      })
-      .finally(() => {
-        if (cancelled) {
-          return;
-        }
-        setFolderLoading(false);
-      });
+    const loadFolder = () =>
+      controller
+        .fetchFolderBooks(openFolderId)
+        .then((items) => {
+          if (cancelled) {
+            return;
+          }
+          setFolderItems(items);
+          setFolderLoading(false);
+        })
+        .catch((err) => {
+          if (cancelled) {
+            return;
+          }
+          if (!autoRetried) {
+            autoRetried = true;
+            window.setTimeout(() => {
+              if (!cancelled) {
+                void loadFolder();
+              }
+            }, 1500);
+            return;
+          }
+          setFolderError(err?.message || "读取合集内容失败，请稍后重试。");
+          setFolderLoading(false);
+        });
+    void loadFolder();
     // 用 collection_id(原始类型)而不是 openFolder(对象引用)做依赖——
     // reload() 每次都会给同一个文件夹造一个新对象(见上面 setOpenFolder 里
     // 的 items.find(...)),按对象引用算依赖会导致"没真的切换文件夹"也
@@ -196,7 +227,8 @@ export function CategoriesView() {
     return () => {
       cancelled = true;
     };
-  }, [controller, openFolderId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [controller, openFolderId, folderRetryTick]);
 
   if (openFolder) {
     return (
@@ -215,7 +247,17 @@ export function CategoriesView() {
         {folderLoading ? (
           <div className="events-empty">正在加载…</div>
         ) : folderError ? (
-          <div className="events-empty">{folderError}</div>
+          <div className="events-empty">
+            <p>{folderError}</p>
+            <button
+              type="button"
+              className="app-button secondary"
+              style={{ marginTop: 12 }}
+              onClick={() => setFolderRetryTick((tick) => tick + 1)}
+            >
+              重试
+            </button>
+          </div>
         ) : folderItems.length === 0 ? (
           <EmptyState
             instrument="balance"
@@ -257,7 +299,21 @@ export function CategoriesView() {
       {listLoading ? (
         <div className="events-empty">正在加载合集…</div>
       ) : listError ? (
-        <div className="events-empty">{listError}</div>
+        <div className="events-empty">
+          <p>{listError}</p>
+          <button
+            type="button"
+            className="app-button secondary"
+            style={{ marginTop: 12 }}
+            onClick={() => {
+              // 重置自动重试标志,允许新的一轮“自动一次 + 手动兑底”
+              listAutoRetriedRef.current = false;
+              void reload();
+            }}
+          >
+            重试
+          </button>
+        </div>
       ) : collections.length === 0 ? (
         <EmptyState
           id="categories-empty"

--- a/frontend/src/styles/pages/home/library-shell.css
+++ b/frontend/src/styles/pages/home/library-shell.css
@@ -196,6 +196,15 @@ body.is-soft-reader-open {
     width: 0;
     height: 0;
   }
+
+  /* 合集/文件夹视图与图书馆共用 .library-view 壳(宽度/flex),但 Tailwind v4
+     的 @utility 生成顺序不跟随源码序(实测产物里 .library-view 排在
+     .categories-view 之后),同元素上 library-view 的 overflow:hidden 会
+     覆盖这里的 overflow-y:auto,导致合集内容无法滚动——用双类组合把
+     specificity 提到 (0,2,0),与生成顺序脱钩。 */
+  &.library-view {
+    overflow-y: auto;
+  }
 }
 
 /* 收藏 tab：与合集同宽同滚动壳 */
@@ -211,6 +220,11 @@ body.is-soft-reader-open {
   &::-webkit-scrollbar {
     width: 0;
     height: 0;
+  }
+
+  /* 同 categories-view：防 .library-view 的 overflow:hidden 层叠覆盖。 */
+  &.library-view {
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
## 问题

桌面端/Web 图书馆页三个影响日常使用的 bug（4.1.10 可复现）：

1. **图书馆「全部书库」最多只显示 24 本文献**：超过一页后无法加载更多（滚动自动加载与「更多」按钮均失效）。
2. **合集页（含收藏 tab）内容超出屏幕后无法向下滑动**。
3. **合集列表偶发加载不出来**：桌面端启动早期后端未就绪（日志里见过 90s 端口等待超时）或后端被大任务短暂拖住时，一次拉取失败就定格在错误文字，只能切 tab 重进。

## 根因与修复

### ① 图书馆分页：后端 `/api/v1/documents` 缺 `total` 字段

前端 `document-library-source.ts` 的分页判断是 `hasMore = offset + documents.length < total`，而 `DocumentListView` 只有 `documents` 没有 `total`——前端 fallback 成「当前页大小」，于是第一页（24 本）之后 `hasMore` 恒为 `false`。

- `DocumentListView` 增加 `total`（与列表同一套过滤条件的 `COUNT(*)`）
- db 层把过滤子句抽出为 `build_document_filters()`，供 `list_documents`/`count_documents` 共用，避免两份过滤逻辑发散
- API 测试补 total 断言

### ② 合集/收藏无法滚动：Tailwind v4 `@utility` 层叠顺序

`categories-view`/`favorites-view` 与图书馆共用 `.library-view` 壳，而后者声明了 `overflow: hidden`。v4 的 `@utility` 生成顺序不跟随源码序（实测产物里 `.library-view` 排在 `.categories-view` 之后），同优先级下 `overflow: hidden` 覆盖 `overflow-y: auto`，导致合集与收藏视图无法纵向滚动。

修复：给两个 utility 追加 `&.library-view` 双类规则（specificity (0,2,0)），与生成顺序脱钩。

### ③ 合集加载无容错

`CategoriesView` 的列表与文件夹内容拉取，失败一次即定格错误态。修复：

- 两处加载均在失败后静默自动重试一次（1.5s，与桌面端启动时序对齐），仍失败才亮错误
- 两个错误态补手动「重试」按钮

## 顺手修复

- `versioned_migrations_are_idempotent` 断言没跟上 v4.1.9 的 v3 迁移（消息树分支），断言从 2 改为 3——该测试在 main 上一直是红的
- `.gitignore` 补 `secrets/`、`docker-compose.override.yml`、`output/mcp-downloads/`，防本地凭据误提交

## 验证

- `cargo test documents` / `cargo test collections`：7+1 全过（含新增 total 断言）
- 前端组件测试 `home-app-component` / `documents-library-source` / `recent-jobs-library-component`：19/19 过
- 构建产物确认 `.categories-view.library-view{overflow-y:auto}` 双类规则已生成
- Windows 实机打包安装验证：28 本文献全部加载、合集可正常滚动、合集加载失败自动重试

> 说明：`frontend` 基线的 `typecheck` 与 `css-color-literals`、`visual:check` 在 main 上已有失败，与本 PR 无关（已在基线复核确认）。
